### PR TITLE
Add Support for Base32 Encoded Secrets

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "FiveBits",
+        "repositoryURL": "https://github.com/gaetanomatonti/FiveBits.git",
+        "state": {
+          "branch": "feature/decoding",
+          "revision": "4ebf272f481ea0357c838b6b8ebbc38870db99bd",
+          "version": null
+        }
+      },
+      {
         "package": "swift-crypto",
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "FiveBits",
         "repositoryURL": "https://github.com/gaetanomatonti/FiveBits.git",
         "state": {
-          "branch": "feature/decoding",
-          "revision": "4ebf272f481ea0357c838b6b8ebbc38870db99bd",
-          "version": null
+          "branch": null,
+          "revision": "6135958239c3071fe8a36e04df75541b73c3a23d",
+          "version": "0.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,13 +17,15 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.0"),
+    .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.1.0")),
+    .package(url: "https://github.com/gaetanomatonti/FiveBits.git", .branch("feature/decoding"))
   ],
   targets: [
     .target(
       name: "Uno",
       dependencies: [
-        .product(name: "Crypto", package: "swift-crypto")
+        .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "FiveBits", package: "FiveBits")
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.1.0")),
-    .package(url: "https://github.com/gaetanomatonti/FiveBits.git", .branch("feature/decoding"))
+    .package(url: "https://github.com/gaetanomatonti/FiveBits.git", .upToNextMajor(from: "0.1.0"))
   ],
   targets: [
     .target(

--- a/Sources/Uno/Secret.swift
+++ b/Sources/Uno/Secret.swift
@@ -10,6 +10,7 @@ import CryptoKit
 import Crypto
 #endif
 
+import FiveBits
 import Foundation
 
 /// An object containing information for a one-time password hash secret.
@@ -29,11 +30,21 @@ public struct Secret {
   
   // MARK: - Init
   
-  /// Creates an instance of `Secret` from an ASCII encoded String.
-  /// - Parameter ascii: The ASCII encoded String.
+  /// Creates an instance of `Secret` from an ASCII encoded `String`.
+  /// - Parameter ascii: The ASCII encoded `String`.
   public init(ascii string: String) throws {
     guard let data = string.data(using: .ascii) else {
       throw Error.asciiConversionToDataFailed
+    }
+    
+    self.data = data
+  }
+  
+  /// Creates an instance of `Secret` from a Base32 encoded `String`.
+  /// - Parameter base32String: The Base32 encoded `String`.
+  public init(base32Encoded base32String: String) throws {
+    guard let data = Data(base32Encoded: base32String) else {
+      throw Error.base32DecodingFailed
     }
     
     self.data = data
@@ -65,10 +76,15 @@ public extension Secret {
     /// The conversion from ASCII to data bytes failed.
     case asciiConversionToDataFailed
     
+    case base32DecodingFailed
+    
     public var errorDescription: String? {
       switch self {
         case .asciiConversionToDataFailed:
           return "The conversion from ASCII to data bytes failed."
+          
+        case .base32DecodingFailed:
+          return "The decoding of the Base32 string failed."
       }
     }
   }


### PR DESCRIPTION
### Description
This PR adds support for secrets from Base32 encoded Strings.
Implementation depends on gaetanomatonti/FiveBits#2 and requires it to be merged, so this PR will be draft until a release is available.