### PR TITLE
Fix Failed URI Parsing for Missing Period

### DIFF
--- a/Sources/Uno/OneTimePassword/Kind.swift
+++ b/Sources/Uno/OneTimePassword/Kind.swift
@@ -23,6 +23,14 @@ public extension OneTimePassword {
     
     /// An OTP generated from a time-based generator (TOTP).
     case timeBased(timestep: TimeInterval)
+    
+    // MARK: - Constants
+    
+    /// The default kind for counter-based generators.
+    static let defaultCounterBased: Self = .counterBased(counter: 0)
+    
+    /// The default kind for time-based generators.
+    static let defaultTimeBased: Self = .timeBased(timestep: 30)
   }
 }
 

--- a/Sources/Uno/OneTimePassword/Metadata.swift
+++ b/Sources/Uno/OneTimePassword/Metadata.swift
@@ -10,16 +10,16 @@ public extension OneTimePassword {
   /// An object containing the information necessary to generate an OTP to authenticate to a service.
   struct Metadata {    
     /// The secret to seed into the generator.
-    let secret: Secret
+    public let secret: Secret
     
     /// The amount of digits composing the authentication code.
-    let codeLength: Length
+    public let codeLength: Length
     
     /// The hash function used to generate the authentication code's hash.
-    let algorithm: Algorithm
+    public let algorithm: Algorithm
     
     /// The kind of One Time Password.
-    let kind: Kind
+    public let kind: Kind
     
     // MARK: - Init
     

--- a/Sources/Uno/URIParser.swift
+++ b/Sources/Uno/URIParser.swift
@@ -110,14 +110,14 @@ extension URIParser {
     switch kindKey {
       case .hotp:
         guard let counterValue = items[.counter], let counter = UInt64(counterValue) else {
-          throw Error.missingCounter
+          return .defaultCounterBased
         }
         
         return .counterBased(counter: counter)
         
       case .totp:
         guard let periodValue = items[.period], let period = TimeInterval(periodValue) else {
-          throw Error.missingPeriod
+          return .defaultTimeBased
         }
         
         return .timeBased(timestep: period)
@@ -172,11 +172,5 @@ extension URIParser {
     
     /// The URI query items are missing the secret string.
     case missingSecret
-    
-    /// The URI query items are missing the counter value. Counter is required for counter based generators, which generate HOTPs.
-    case missingCounter
-  
-    /// The URI query items are missing the period value. Period is required for time based generators, which generate TOTPs.
-    case missingPeriod
   }
 }

--- a/Tests/UnoTests/URIParserTests.swift
+++ b/Tests/UnoTests/URIParserTests.swift
@@ -36,18 +36,16 @@ final class URIParserTests: XCTestCase {
     }
   }
   
-  func testMissingPeriodShouldThrow() {
-    let sut = "otpauth://totp/Uno:john.doe@email.com?issuer=Uno"
-    XCTAssertThrowsError(try URIParser(uri: sut)) { error in
-      XCTAssertEqual(error as! URIParser.Error, URIParser.Error.missingPeriod)
-    }
+  func testMissingPeriodShouldParseWithDefaultValue() throws {
+    let sut = "otpauth://totp/Uno:john.doe@email.com?secret=JBSWY3DPEHPK3PXP&issuer=Uno"
+    let parser = try URIParser(uri: sut)
+    XCTAssertEqual(parser.kind, .defaultTimeBased)
   }
   
-  func testMissingCounterShouldThrow() {
-    let sut = "otpauth://hotp/Uno:john.doe@email.com?issuer=Uno"
-    XCTAssertThrowsError(try URIParser(uri: sut)) { error in
-      XCTAssertEqual(error as! URIParser.Error, URIParser.Error.missingCounter)
-    }
+  func testMissingCounterShouldParseWithDefaultValue() throws {
+    let sut = "otpauth://hotp/Uno:john.doe@email.com?secret=JBSWY3DPEHPK3PXP&issuer=Uno"
+    let parser = try URIParser(uri: sut)
+    XCTAssertEqual(parser.kind, .defaultCounterBased)
   }
   
   func testHOTPTypeShouldBeCorrect() throws {


### PR DESCRIPTION
### Description
This PR fixes a bug where the URI Parser fails to parse URIs which are missing the period or counter query item.

### Context
This fix is needed as some issuers do not provide explicit values for these properties.