### PR TITLE
Release 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "127d3745c37b5705e4bc8d16c7951c48dcc3332c",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.1.0")),
+    .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "2.0.0")),
     .package(url: "https://github.com/gaetanomatonti/FiveBits.git", .upToNextMajor(from: "0.1.0"))
   ],
   targets: [


### PR DESCRIPTION
### Description 
This PR releases a new version of Uno with the following changes:
- Fixes the URIParser not able to parse URIs not containing period or counter items
- Adds some information to the Metadata object (issuer and account)
- Bumps the version of [swift-crypto](https://github.com/apple/swift-crypto) to 2.0.0