### PR TITLE
Release 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "127d3745c37b5705e4bc8d16c7951c48dcc3332c",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.1.0")),
+    .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "2.0.0")),
     .package(url: "https://github.com/gaetanomatonti/FiveBits.git", .upToNextMajor(from: "0.1.0"))
   ],
   targets: [

--- a/Sources/Uno/OneTimePassword/Kind.swift
+++ b/Sources/Uno/OneTimePassword/Kind.swift
@@ -23,6 +23,14 @@ public extension OneTimePassword {
     
     /// An OTP generated from a time-based generator (TOTP).
     case timeBased(timestep: TimeInterval)
+    
+    // MARK: - Constants
+    
+    /// The default kind for counter-based generators.
+    static let defaultCounterBased: Self = .counterBased(counter: 0)
+    
+    /// The default kind for time-based generators.
+    static let defaultTimeBased: Self = .timeBased(timestep: 30)
   }
 }
 

--- a/Sources/Uno/OneTimePassword/Metadata.swift
+++ b/Sources/Uno/OneTimePassword/Metadata.swift
@@ -8,7 +8,16 @@ import Foundation
 
 public extension OneTimePassword {
   /// An object containing the information necessary to generate an OTP to authenticate to a service.
-  struct Metadata {    
+  struct Metadata: Identifiable {
+    /// The identifier of the `Metadata` object.
+    public let id = UUID()
+    
+    /// The issuer of the service authenticated through the OTP.
+    public let issuer: String?
+    
+    /// The account secured with the OTP authentication.
+    public let account: String?
+    
     /// The secret to seed into the generator.
     public let secret: Secret
     
@@ -29,7 +38,16 @@ public extension OneTimePassword {
     ///   - codeLength: The amount of digits composing the authentication code.
     ///   - algorithm: The hash function used to generate the authentication code's hash.
     ///   - kind: The kind of One Time Password.
-    public init(secret: Secret, codeLength: Length, algorithm: Algorithm, kind: Kind) {
+    public init(
+      issuer: String? = nil,
+      account: String? = nil,
+      secret: Secret,
+      codeLength: Length,
+      algorithm: Algorithm,
+      kind: Kind
+    ) {
+      self.issuer = issuer
+      self.account = account
       self.secret = secret
       self.codeLength = codeLength
       self.algorithm = algorithm
@@ -41,6 +59,8 @@ public extension OneTimePassword {
     public init(uri: String) throws {
       let parser = try URIParser(uri: uri)
       
+      issuer = parser.issuer
+      account = parser.account
       secret = parser.secret
       codeLength = parser.codeLength
       algorithm = parser.algorithm

--- a/Sources/Uno/OneTimePassword/Metadata.swift
+++ b/Sources/Uno/OneTimePassword/Metadata.swift
@@ -10,16 +10,16 @@ public extension OneTimePassword {
   /// An object containing the information necessary to generate an OTP to authenticate to a service.
   struct Metadata {    
     /// The secret to seed into the generator.
-    let secret: Secret
+    public let secret: Secret
     
     /// The amount of digits composing the authentication code.
-    let codeLength: Length
+    public let codeLength: Length
     
     /// The hash function used to generate the authentication code's hash.
-    let algorithm: Algorithm
+    public let algorithm: Algorithm
     
     /// The kind of One Time Password.
-    let kind: Kind
+    public let kind: Kind
     
     // MARK: - Init
     

--- a/Sources/Uno/URIParser.swift
+++ b/Sources/Uno/URIParser.swift
@@ -110,14 +110,14 @@ extension URIParser {
     switch kindKey {
       case .hotp:
         guard let counterValue = items[.counter], let counter = UInt64(counterValue) else {
-          throw Error.missingCounter
+          return .defaultCounterBased
         }
         
         return .counterBased(counter: counter)
         
       case .totp:
         guard let periodValue = items[.period], let period = TimeInterval(periodValue) else {
-          throw Error.missingPeriod
+          return .defaultTimeBased
         }
         
         return .timeBased(timestep: period)
@@ -172,11 +172,5 @@ extension URIParser {
     
     /// The URI query items are missing the secret string.
     case missingSecret
-    
-    /// The URI query items are missing the counter value. Counter is required for counter based generators, which generate HOTPs.
-    case missingCounter
-  
-    /// The URI query items are missing the period value. Period is required for time based generators, which generate TOTPs.
-    case missingPeriod
   }
 }

--- a/Sources/Uno/URIParser.swift
+++ b/Sources/Uno/URIParser.swift
@@ -18,6 +18,9 @@ struct URIParser {
 
     /// The digits item key.
     case digits
+    
+    /// The issuer item key
+    case issuer
 
     /// The period item key.
     case period
@@ -33,6 +36,12 @@ struct URIParser {
   
   // MARK: - Stored Properties
   
+  /// The issuer of the service authenticated through the OTP.
+  let issuer: String?
+  
+  /// The account secured with the OTP authentication.
+  let account: String?
+
   /// The algorithm used by the service to generate OTPs.
   let algorithm: OneTimePassword.Algorithm
   
@@ -81,6 +90,10 @@ struct URIParser {
     // The following values are optional and have fallback values.
     self.algorithm = URIParser.algorithm(for: queryItems[.algorithm])
     self.codeLength = try URIParser.codeLength(for: queryItems[.digits])
+    
+    let (issuer, account) = Self.extractLabelItems(from: components.path)
+    self.issuer = issuer ?? queryItems[.issuer]
+    self.account = account
   }
 }
 
@@ -122,6 +135,27 @@ extension URIParser {
         
         return .timeBased(timestep: period)
     }
+  }
+  
+  /// Gets the issuer and account from the path of the URI.
+  ///
+  /// - Note: The correct format of the label should be `issuer:account`.
+  /// - Parameter label: The label from which to extract the issuer and account strings.
+  /// - Returns: A tuple of `String`s containing the issuer and account.
+  static func extractLabelItems(from label: String) -> (issuer: String?, account: String?) {
+    var label = label
+    
+    if label.hasPrefix("/") {
+      label.removeFirst()
+    }
+    
+    let components = label.components(separatedBy: ":")
+    
+    guard components.count == 2 else {
+      return (nil, nil)
+    }
+    
+    return (components.first, components.last)
   }
   
   /// Gets the algorithm to use to generate the OTP.

--- a/Tests/UnoTests/URIParserTests.swift
+++ b/Tests/UnoTests/URIParserTests.swift
@@ -59,6 +59,18 @@ final class URIParserTests: XCTestCase {
     let parser = try URIParser(uri: sut)
     XCTAssertEqual(parser.kind, .timeBased(timestep: 30))
   }
+  
+  func testIssuerShouldBeCorrect() throws {
+    let sut = "otpauth://totp/Uno:john.doe@email.com?issuer=Uno&secret=JBSWY3DPEHPK3PXP&period=30"
+    let parser = try URIParser(uri: sut)
+    XCTAssertEqual(parser.issuer, "Uno")
+  }
+  
+  func testAccountShouldBeCorrect() throws {
+    let sut = "otpauth://totp/Uno:john.doe@email.com?issuer=Uno&secret=JBSWY3DPEHPK3PXP&period=30"
+    let parser = try URIParser(uri: sut)
+    XCTAssertEqual(parser.account, "john.doe@email.com")
+  }
     
   func testSecretShouldBeCorrect() throws {
     let sut = "otpauth://totp/Uno:john.doe@email.com?issuer=Uno&secret=JBSWY3DPEHPK3PXP&period=30"

--- a/Tests/UnoTests/URIParserTests.swift
+++ b/Tests/UnoTests/URIParserTests.swift
@@ -36,18 +36,16 @@ final class URIParserTests: XCTestCase {
     }
   }
   
-  func testMissingPeriodShouldThrow() {
-    let sut = "otpauth://totp/Uno:john.doe@email.com?issuer=Uno"
-    XCTAssertThrowsError(try URIParser(uri: sut)) { error in
-      XCTAssertEqual(error as! URIParser.Error, URIParser.Error.missingPeriod)
-    }
+  func testMissingPeriodShouldParseWithDefaultValue() throws {
+    let sut = "otpauth://totp/Uno:john.doe@email.com?secret=JBSWY3DPEHPK3PXP&issuer=Uno"
+    let parser = try URIParser(uri: sut)
+    XCTAssertEqual(parser.kind, .defaultTimeBased)
   }
   
-  func testMissingCounterShouldThrow() {
-    let sut = "otpauth://hotp/Uno:john.doe@email.com?issuer=Uno"
-    XCTAssertThrowsError(try URIParser(uri: sut)) { error in
-      XCTAssertEqual(error as! URIParser.Error, URIParser.Error.missingCounter)
-    }
+  func testMissingCounterShouldParseWithDefaultValue() throws {
+    let sut = "otpauth://hotp/Uno:john.doe@email.com?secret=JBSWY3DPEHPK3PXP&issuer=Uno"
+    let parser = try URIParser(uri: sut)
+    XCTAssertEqual(parser.kind, .defaultCounterBased)
   }
   
   func testHOTPTypeShouldBeCorrect() throws {


### PR DESCRIPTION
### Description 
This PR releases a new version of Uno with the following changes:
- Fixes the URIParser not able to parse URIs not containing period or counter items
- Adds some information to the Metadata object (issuer and account)
- Bumps the version of [swift-crypto](https://github.com/apple/swift-crypto) to 2.0.0