### PR TITLE
Release 0.4.0

### DIFF
--- a/Sources/Uno/Extensions/URLQueryItem+Extensions.swift
+++ b/Sources/Uno/Extensions/URLQueryItem+Extensions.swift
@@ -6,7 +6,27 @@
 
 import Foundation
 
+extension URLQueryItem {
+  /// Creates an instance of `URLQueryItem`.
+  /// - Parameters:
+  ///   - key: The `URIParser.ItemKey` representing the name of the query item.
+  ///   - value: The value of the query item.
+  init(_ key: URIParser.ItemKey, value: String?) {
+    self.init(name: key.rawValue, value: value)
+  }
+}
+
 extension Array where Element == URLQueryItem {
+  
+  // MARK: - Computed Properties
+  
+  /// The items sorted by their names in ascending order.
+  var sorted: Self {
+    sorted(by: { $0.name < $1.name })
+  }
+  
+  // MARK: - Functions
+  
   /// Accesses the value of the `URLQueryItem` for the specified `URIParser.ItemKey`.
   /// - Parameter key: The `URIParser.ItemKey` representing the name of the `URLQueryItem`.
   /// - Returns: An optional `String` representing the value of the query item. `nil` if a value couldn't be found for the specified key.

--- a/Sources/Uno/OneTimePassword/Kind.swift
+++ b/Sources/Uno/OneTimePassword/Kind.swift
@@ -26,11 +26,48 @@ public extension OneTimePassword {
     
     // MARK: - Constants
     
+    /// The default counter value for counter-based generators.
+    public static let defaultCounter: UInt64 = 0
+    
     /// The default kind for counter-based generators.
-    static let defaultCounterBased: Self = .counterBased(counter: 0)
+    public static let defaultCounterBased: Self = .counterBased(counter: defaultCounter)
+    
+    /// The default timestep value for time-based generators.
+    public static let defaultTimestep: TimeInterval = 30
     
     /// The default kind for time-based generators.
-    static let defaultTimeBased: Self = .timeBased(timestep: 30)
+    public static let defaultTimeBased: Self = .timeBased(timestep: defaultTimestep)
+    
+    // MARK: - Computed Properties
+    
+    /// The key of the OTP kind.
+    var key: Key {
+      switch self {
+        case .counterBased:
+          return .hotp
+          
+        case .timeBased:
+          return .totp
+      }
+    }
+    
+    /// The value of the counter. `nil` if the kind is not `.counterBased`.
+    public var counter: UInt64? {
+      if case let .counterBased(counter) = self {
+        return counter
+      }
+      
+      return nil
+    }
+    
+    /// The value of the timestep. `nil` if the kind is not `.timeBased`.
+    public var timestep: TimeInterval? {
+      if case let .timeBased(timestep) = self {
+        return timestep
+      }
+      
+      return nil
+    }
   }
 }
 

--- a/Sources/Uno/OneTimePassword/Metadata.swift
+++ b/Sources/Uno/OneTimePassword/Metadata.swift
@@ -30,6 +30,38 @@ public extension OneTimePassword {
     /// The kind of One Time Password.
     public let kind: Kind
     
+    // MARK: - Computed Properties
+    
+    /// The `otpauth` `URI` containing information for the service authentication.
+    public var uri: URL? {
+      var components = URLComponents()
+      components.scheme = URIParser.scheme
+      components.host = kind.key.rawValue
+      
+      let label = [issuer, account].compactMap { $0 }.joined(separator: ":")
+      components.path = label.isEmpty ? "" : ("/" + label)
+      
+      components.queryItems = [
+        URLQueryItem(.algorithm, value: algorithm.rawValue),
+        URLQueryItem(.digits, value: codeLength.rawValue.description),
+        URLQueryItem(.secret, value: secret.string)
+      ]
+      
+      if let issuer = issuer {
+        components.queryItems?.append(URLQueryItem(.issuer, value: issuer))
+      }
+      
+      if let period = kind.timestep {
+        components.queryItems?.append(URLQueryItem(.period, value: Int(period).description))
+      }
+      
+      if let counter = kind.counter {
+        components.queryItems?.append(URLQueryItem(.counter, value: counter.description))
+      }
+      
+      return components.url
+    }
+    
     // MARK: - Init
     
     /// Creates an instance of the `Metadata` object.

--- a/Sources/Uno/OneTimePassword/Secret.swift
+++ b/Sources/Uno/OneTimePassword/Secret.swift
@@ -19,6 +19,9 @@ public extension OneTimePassword {
     
     // MARK: - Stored Properties
     
+    /// The secret in `String` format.
+    let string: String
+    
     /// The bytes of the secret.
     let data: Data
     
@@ -38,6 +41,7 @@ public extension OneTimePassword {
         throw Error.asciiConversionToDataFailed
       }
       
+      self.string = string
       self.data = data
     }
     
@@ -48,12 +52,14 @@ public extension OneTimePassword {
         throw Error.base32DecodingFailed
       }
       
+      self.string = base32String
       self.data = data
     }
     
     /// Creates an instance of `Secret` from an ASCII encoded String.
     /// - Parameter string: The hexadecimal `String` representation of the secret.
     public init(hex string: String) throws {
+      self.string = string
       self.data = try Data(hex: string)
     }
   }

--- a/Sources/Uno/URIParser.swift
+++ b/Sources/Uno/URIParser.swift
@@ -32,7 +32,7 @@ struct URIParser {
   // MARK: - Constants
   
   /// The scheme of the `otpauth` URI.
-  private static let scheme = "otpauth"
+  internal static let scheme = "otpauth"
   
   // MARK: - Stored Properties
   
@@ -166,7 +166,7 @@ extension URIParser {
       return .sha1
     }
     
-    return OneTimePassword.Algorithm.from(value)
+    return OneTimePassword.Algorithm.from(value.uppercased())
   }
   
   /// Gets the length in digits of the OTP that should be generated.

--- a/Tests/UnoTests/MetadataTests.swift
+++ b/Tests/UnoTests/MetadataTests.swift
@@ -1,0 +1,55 @@
+//
+//  Uno
+//
+//  Created by Gaetano Matonti on 25/09/21.
+//
+
+import XCTest
+@testable import Uno
+
+/// Test case for the `OneTimePassword.Metadata` type.
+final class MetadataTests: XCTestCase {
+  func testURIShouldBeCorrect() throws {
+    let metadata = try OneTimePassword.Metadata(
+      issuer: "Uno",
+      account: "john@example.com",
+      secret: OneTimePassword.Secret(ascii: "HelloWorld"),
+      codeLength: .eight,
+      algorithm: .sha256,
+      kind: .timeBased(timestep: 10)
+    )
+    
+    let uri = try XCTUnwrap(metadata.uri)
+    let sut = try XCTUnwrap(URLComponents(string: uri.absoluteString))
+    
+    let expectedResult = try XCTUnwrap(
+      URLComponents(string: "otpauth://totp/Uno:john@example.com?issuer=Uno&secret=HelloWorld&digits=8&algorithm=SHA256&period=10")
+    )
+    
+    XCTAssertEqual(sut.scheme, expectedResult.scheme)
+    XCTAssertEqual(sut.host, expectedResult.host)
+    XCTAssertEqual(sut.path, expectedResult.path)
+    XCTAssertEqual(sut.queryItems?.sorted, expectedResult.queryItems?.sorted)
+  }
+  
+  func testURIWithoutLabelShouldBeCorrect() throws {
+    let metadata = try OneTimePassword.Metadata(
+      secret: OneTimePassword.Secret(ascii: "HelloWorld"),
+      codeLength: .eight,
+      algorithm: .sha256,
+      kind: .timeBased(timestep: 10)
+    )
+    
+    let uri = try XCTUnwrap(metadata.uri)
+    let sut = try XCTUnwrap(URLComponents(string: uri.absoluteString))
+    
+    let expectedResult = try XCTUnwrap(
+      URLComponents(string: "otpauth://totp?secret=HelloWorld&digits=8&algorithm=SHA256&period=10")
+    )
+    
+    XCTAssertEqual(sut.scheme, expectedResult.scheme)
+    XCTAssertEqual(sut.host, expectedResult.host)
+    XCTAssertEqual(sut.path, expectedResult.path)    
+    XCTAssertEqual(sut.queryItems?.sorted, expectedResult.queryItems?.sorted)
+  }
+}


### PR DESCRIPTION
### Description
This PR releases a new version of Uno with the following changes:
- Added a `uri` property to construct a `otpauth` URI from a `Metadata` instance