### PR TITLE
Update `minimumKeySize` for SHA1 Algorithm

### DIFF
--- a/Sources/Uno/OneTimePassword/Algorithm.swift
+++ b/Sources/Uno/OneTimePassword/Algorithm.swift
@@ -30,7 +30,7 @@ public extension OneTimePassword {
     var minimumKeySize: Int {
       switch self {
         case .sha1:
-          return 20
+          return 10
           
         case .sha256:
           return 32


### PR DESCRIPTION
# Description

Fix minimumKeySize for some service use 10 or 16 instead of 20 about length of data